### PR TITLE
Fix failing tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,4 +73,4 @@ def test_end_time(scope="module"):
     test_start_time = datetime.now(tz=pytz.utc).replace(
         minute=0, second=0, microsecond=0
     )
-    return test_start_time - timedelta(hours=24)
+    return test_start_time - timedelta(days=7)

--- a/tests/test_electricity_meter.py
+++ b/tests/test_electricity_meter.py
@@ -15,6 +15,7 @@ def test_electricity_meter_existence(
 ) -> None:
     """Test that the electricity meter end point has the right structure"""
     meter_details = electricity_meter.verify()
+    assert meter_details
     assert meter_details["mpan"] == electricity_mpan
     assert meter_details["gsp"] in grid_supply_points
     assert isinstance(meter_details["profile_class"], int)
@@ -23,6 +24,7 @@ def test_electricity_meter_existence(
 def test_electricity_meter_consumption(electricity_meter: ElectricityMeter) -> None:
     """Test that the electricity meter consumption end point has the right structure"""
     consumption = electricity_meter.consumption()
+    assert consumption
     assert isinstance(consumption[0]["consumption"], float)
     assert isinstance(consumption[0]["interval_start"], datetime)
     assert isinstance(consumption[0]["interval_end"], datetime)
@@ -36,6 +38,7 @@ def test_electricity_meter_consumption_halfhourly(
     consumption = electricity_meter.consumption(
         period_from=start_time, period_to=test_end_time
     )
+    assert consumption
     assert len(consumption) <= 47
 
 
@@ -47,7 +50,7 @@ def test_electricity_meter_consumption_hourly(
     consumption = electricity_meter.consumption(
         period_from=start_time, period_to=test_end_time, group_by="hour"
     )
-    assert consumption is not None
+    assert consumption
     interval_hrs = [
         int((week["interval_end"] - week["interval_start"]).seconds / 3600.0)
         for week in consumption
@@ -63,7 +66,7 @@ def test_electricity_meter_consumption_daily(
     consumption = electricity_meter.consumption(
         period_from=start_time, period_to=test_end_time, group_by="day"
     )
-    assert consumption is not None
+    assert consumption
     interval_days = [
         (week["interval_end"] - week["interval_start"]).days for week in consumption
     ]
@@ -78,7 +81,7 @@ def test_electricity_meter_consumption_weekly(
     consumption = electricity_meter.consumption(
         period_from=start_time, period_to=test_end_time, group_by="week"
     )
-    assert consumption is not None
+    assert consumption
     interval_days = [
         (week["interval_end"] - week["interval_start"]).days for week in consumption
     ]
@@ -94,7 +97,7 @@ def test_electricity_meter_consumption_monthly(
     consumption = electricity_meter.consumption(
         period_from=start_time, period_to=test_end_time, group_by="month"
     )
-    assert consumption is not None
+    assert consumption
     interval_days = [
         (week["interval_end"] - week["interval_start"]).days for week in consumption
     ]
@@ -110,7 +113,7 @@ def test_electricity_meter_consumption_quarterly(
     consumption = electricity_meter.consumption(
         period_from=start_time, period_to=test_end_time, group_by="quarter"
     )
-    assert consumption is not None
+    assert consumption
     interval_days = [
         (week["interval_end"] - week["interval_start"]).days for week in consumption
     ]

--- a/tests/text_fixtures.py
+++ b/tests/text_fixtures.py
@@ -11,3 +11,8 @@ def test_have_electricity_mpan(electricity_mpan):
 def test_have_electricity_serial_number(electricity_serial_number):
     """Test the electricity_serial_number fixture"""
     assert electricity_serial_number is not None
+
+
+def test_have_test_end_time(test_end_time):
+    """Test the test_end_time fixture"""
+    assert test_end_time is not None


### PR DESCRIPTION
Push test_end_time further into the past to ensure that the readings have been recorded.

Closes #14.